### PR TITLE
Re-implements trailingBorderColor

### DIFF
--- a/lib/src/animated_loading_border_widget.dart
+++ b/lib/src/animated_loading_border_widget.dart
@@ -34,8 +34,8 @@ class AnimatedLoadingBorder extends StatefulWidget {
   final Color borderColor;
 
   /// Defines the color for the trailing part of the border
-  /// Default value [Colors.black]
-  final Color trailingBorderColor;
+  /// Default value [borderColor.withOpacity(0)]
+  final Color? trailingBorderColor;
 
   /// Used to add child widget padding
   /// Default value [EdgeInsets.zero]
@@ -45,10 +45,6 @@ class AnimatedLoadingBorder extends StatefulWidget {
   /// Default value [true]
   final bool startWithRandomPosition;
 
-  /// Used to set starting color of SweepGradient
-  /// Default value [true]
-  final bool isTrailingTransparent;
-
   const AnimatedLoadingBorder({
     required this.child,
     this.controller,
@@ -57,10 +53,9 @@ class AnimatedLoadingBorder extends StatefulWidget {
     this.borderWidth = 1,
     this.borderLength = 0.2,
     this.borderColor = Colors.black,
-    this.trailingBorderColor = Colors.black,
+    this.trailingBorderColor,
     this.padding = EdgeInsets.zero,
     this.startWithRandomPosition = true,
-    this.isTrailingTransparent = true,
     Key? key,
   }) : super(key: key);
 
@@ -130,8 +125,8 @@ class _AnimatedLoadingBorderState extends State<AnimatedLoadingBorder>
         borderWidth: widget.borderWidth,
         gradientLength: widget.borderLength,
         borderColor: borderColor,
-        trailingBorderColor: widget.trailingBorderColor,
-        isTrailingTransparent: widget.isTrailingTransparent,
+        trailingBorderColor: widget.trailingBorderColor
+            ?? borderColor.withOpacity(0),
         startingPosition:
             widget.startWithRandomPosition ? getRandomNumber() : 0,
       ),

--- a/lib/src/animated_loading_border_widget.dart
+++ b/lib/src/animated_loading_border_widget.dart
@@ -25,6 +25,10 @@ class AnimatedLoadingBorder extends StatefulWidget {
   /// Default value [1]
   final double borderWidth;
 
+  /// Defines the length of the visible border in percents
+  /// Default value [0.2] (= 20%)
+  final double borderLength;
+
   /// Defines the color of the border
   /// Default value [Colors.black]
   final Color borderColor;
@@ -51,6 +55,7 @@ class AnimatedLoadingBorder extends StatefulWidget {
     this.duration = const Duration(seconds: 4),
     this.cornerRadius = 0.0,
     this.borderWidth = 1,
+    this.borderLength = 0.2,
     this.borderColor = Colors.black,
     this.trailingBorderColor = Colors.black,
     this.padding = EdgeInsets.zero,
@@ -123,6 +128,7 @@ class _AnimatedLoadingBorderState extends State<AnimatedLoadingBorder>
         animation: _controller,
         cornerRadius: widget.cornerRadius,
         borderWidth: widget.borderWidth,
+        gradientLength: widget.borderLength,
         borderColor: borderColor,
         trailingBorderColor: widget.trailingBorderColor,
         isTrailingTransparent: widget.isTrailingTransparent,

--- a/lib/src/border_painter.dart
+++ b/lib/src/border_painter.dart
@@ -44,6 +44,7 @@ class BorderPainter extends CustomPainter {
     final progress = animation.value;
 
     if (progress > 0.0) {
+      paint.color = borderColor;
       paint.shader = SweepGradient(
         colors: [
           trailingBorderColor,

--- a/lib/src/border_painter.dart
+++ b/lib/src/border_painter.dart
@@ -23,9 +23,6 @@ class BorderPainter extends CustomPainter {
   /// Color for the trailing part of the border
   final Color trailingBorderColor;
 
-  /// Used to set starting color of SweepGradient
-  final bool isTrailingTransparent;
-
   /// Starting position used in SweepGradient
   final int startingPosition;
 
@@ -36,7 +33,6 @@ class BorderPainter extends CustomPainter {
     required this.gradientLength,
     required this.borderColor,
     required this.trailingBorderColor,
-    required this.isTrailingTransparent,
     required this.startingPosition,
   }) : super(repaint: animation);
 
@@ -48,12 +44,9 @@ class BorderPainter extends CustomPainter {
     final progress = animation.value;
 
     if (progress > 0.0) {
-      paint.color = trailingBorderColor;
       paint.shader = SweepGradient(
         colors: [
-          isTrailingTransparent
-              ? Colors.transparent
-              : borderColor.withOpacity(0.1),
+          trailingBorderColor,
           borderColor,
           Colors.transparent,
         ],

--- a/lib/src/border_painter.dart
+++ b/lib/src/border_painter.dart
@@ -14,6 +14,9 @@ class BorderPainter extends CustomPainter {
   /// Width of the border
   final double borderWidth;
 
+  /// Length of the gradient in percents
+  final double gradientLength;
+
   /// Color of the border
   final Color borderColor;
 
@@ -30,6 +33,7 @@ class BorderPainter extends CustomPainter {
     required this.animation,
     required this.cornerRadius,
     required this.borderWidth,
+    required this.gradientLength,
     required this.borderColor,
     required this.trailingBorderColor,
     required this.isTrailingTransparent,
@@ -58,8 +62,8 @@ class BorderPainter extends CustomPainter {
           1.0,
           1.0,
         ],
-        startAngle: math.pi / 8,
-        endAngle: math.pi / 2,
+        startAngle: 0.0,
+        endAngle: gradientLength * 360 * math.pi / 180,
         transform: GradientRotation(
           (math.pi * 2 * progress) + startingPosition,
         ),


### PR DESCRIPTION
Re-implements trailingBorderColor

- Fixing the usage of this parameter (that was not doing anything previously)

Removes isTrailingTransparent parameter

- Increasing the possibilities of customisation
- Getting rid of Colors.transparent as an ending color of the gradient, which is never computing well in Flutter

### Note that this PR contains #2 already merged